### PR TITLE
BP-17--

### DIFF
--- a/src/main/java/com/example/basicback/config/SecurityConfig.java
+++ b/src/main/java/com/example/basicback/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.example.basicback.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http.csrf(csrf -> csrf.disable()).authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/**").permitAll()
+                .anyRequest().authenticated()
+        ).httpBasic(withDefaults());
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/example/basicback/enums/StatusEnum.java
+++ b/src/main/java/com/example/basicback/enums/StatusEnum.java
@@ -1,0 +1,24 @@
+package com.example.basicback.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum StatusEnum {
+
+    OK(200, "OK"),
+    UNAUTHORIZED(401, "UNAUTHORIZED"),
+    BAD_REQUEST(400, "BAD_REQUEST"),
+    NOT_FOUND(404, "NOT_FOUND"),
+    CONFLICT(409, "CONFLICT"),
+    INTERNAL_SERVER_ERROR(500, "INTERNAL_SERVER_ERROR");
+
+    int statusCode;
+    String code;
+
+    StatusEnum(int statusCode, String code) {
+        this.statusCode = statusCode;
+        this.code = code;
+    }
+
+
+}

--- a/src/main/java/com/example/basicback/model/pk/Message.java
+++ b/src/main/java/com/example/basicback/model/pk/Message.java
@@ -1,0 +1,24 @@
+package com.example.basicback.model.pk;
+
+import com.example.basicback.enums.StatusEnum;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Data
+public class Message {
+
+    private LocalDateTime timestamp = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+    private int status;
+    private Boolean result;
+    private String message;
+    private Object data;
+
+    public Message() {
+        this.status = StatusEnum.BAD_REQUEST.getStatusCode();
+        this.result = null;
+        this.message = null;
+        this.data = null;
+    }
+}


### PR DESCRIPTION
# BP-24~26: SecurityConfig 생성 및 HTTP 응답 상태, 메시지 포맷 정의

## 변경 사항 요약 (Summary of Changes)
이 풀리퀘스트는 보안 설정 및 HTTP 응답 상태와 메시지 포맷을 정의하는 세 가지 주요 기능을 추가합니다.

- **BP-24 feat: SecurityConfig 생성**
  - `SecurityConfig` 클래스를 생성하여 보안 설정을 구성했습니다.
  - 사용자 인증 및 권한 부여와 관련된 기본 보안 정책을 설정했습니다.

- **BP-25 feat: HTTP 응답 상태 정의**
  - HTTP 응답 상태를 명확하게 정의하여, 각 요청에 대한 응답 상태를 보다 체계적으로 관리할 수 있도록 했습니다.
  - 일반적인 성공, 실패, 에러 등의 상태 코드를 명시했습니다.

- **BP-26 feat: 메시지 포맷 정의**
  - API 응답 메시지의 포맷을 정의하여, 일관된 응답 구조를 유지하도록 했습니다.
  - 메시지 구조에 포함될 필드와 그 의미를 명확히 했습니다.

## 배경 및 목적 (Background and Motivation)
이번 변경 사항은 보안 설정의 일관성을 높이고, HTTP 응답 상태 및 메시지 포맷을 명확히 정의함으로써 API의 안정성을 강화하는 것을 목적으로 합니다.

- **SecurityConfig**는 애플리케이션의 보안을 관리하고 강화하기 위해 필요합니다.
- 명확한 **HTTP 응답 상태 정의**는 클라이언트와의 통신에서 발생할 수 있는 혼란을 줄이고, 보다 명확한 오류 처리를 가능하게 합니다.
- 일관된 **메시지 포맷**은 클라이언트와의 통신을 표준화하고, 유지보수성을 높입니다.

## 관련 이슈 (Linked Issues)
- 이 풀리퀘스트는 다음의 이슈를 해결합니다:
  - Closes #24
  - Closes #25
  - Closes #26

## 테스트 방법 (Testing Instructions)
다음 단계를 통해 이번 변경 사항을 테스트할 수 있습니다:

1. `SecurityConfig`가 올바르게 적용되었는지 확인하기 위해, 인증이 필요한 API 엔드포인트에 접근합니다.
2. 정의된 HTTP 응답 상태 코드가 올바르게 반환되는지 확인합니다. 예를 들어, 성공적인 요청은 200 상태 코드를, 잘못된 요청은 400 상태 코드를 반환하는지 테스트합니다.
3. API의 응답 메시지 포맷이 일관되게 적용되었는지 확인합니다. 모든 응답이 동일한 구조를 따르고 있는지 검증합니다.

## 기타 참고 사항 (Additional Notes)
이번 변경 사항은 보안 및 API의 일관성을 크게 향상시킵니다. 향후 추가적인 보안 정책이나 응답 메시지 개선이 필요할 수 있으며, 이에 대한 지속적인 검토가 필요합니다.
