### PR TITLE
BP-30 chore: 회원정보 주소항목 제거

### DIFF
--- a/src/main/java/com/example/basicback/controller/UserController.java
+++ b/src/main/java/com/example/basicback/controller/UserController.java
@@ -36,7 +36,7 @@ public class UserController {
     @PostMapping("/register")
     public ResponseEntity<Message> register(HttpServletRequest request, @RequestBody UserDto userDto) {
         log.debug("Accessed IP : {}", request.getRemoteAddr());
-        log.debug("id : {}, birth : {}, name : {}, gender : {}, address : {}", userDto.getId(), userDto.getBirth(), userDto.getName(), userDto.getGender(), userDto.getAddress());
+        log.debug("id : {}, birth : {}, name : {}, gender : {}", userDto.getId(), userDto.getBirth(), userDto.getName(), userDto.getGender());
 
         ResponseEntity<Message> response = userService.register(userDto);
 
@@ -60,7 +60,7 @@ public class UserController {
     @PutMapping("/change/{id}")
     public ResponseEntity<Message> changeInfo(HttpServletRequest request, @PathVariable String id, @RequestBody UserDto userDto) {
         log.debug("Accessed IP : {}", request.getRemoteAddr());
-        log.debug("id : {}, name : {}, birth : {}, gender : {}, address : {}", id, userDto.getName(), userDto.getBirth(), userDto.getGender(), userDto.getAddress());
+        log.debug("id : {}, name : {}, birth : {}, gender : {}", id, userDto.getName(), userDto.getBirth(), userDto.getGender());
 
         ResponseEntity<Message> response = userService.changeInfo(id, userDto);
 

--- a/src/main/java/com/example/basicback/dto/UserDto.java
+++ b/src/main/java/com/example/basicback/dto/UserDto.java
@@ -20,7 +20,6 @@ public class UserDto {
     private LocalDate birth;
     private String name;
     private String gender; // 성별을 문자열로 변경
-    private List<String> address; // 주소를 문자열 리스트로 변경
     @JsonProperty("last_login")
     private LocalDateTime lastLogin;
     private String token;
@@ -32,7 +31,6 @@ public class UserDto {
                 .birth(birth)
                 .name(name)
                 .gender(String.valueOf(gender.charAt(0))) // 문자열에서 첫 번째 문자를 Character로 변환
-                .address(address)
                 .lastLogin(lastLogin)
                 .token(token)
                 .build();

--- a/src/main/java/com/example/basicback/model/pk/User.java
+++ b/src/main/java/com/example/basicback/model/pk/User.java
@@ -38,10 +38,6 @@ public class User {
     @Column(name = "gender", nullable = false)
     private String gender;
 
-    @Column(name = "address", nullable = false)
-    @Convert(converter = ListOneStringConverter.class)
-    private List<String> address;
-
     @Column(name = "last_login")
     private LocalDateTime lastLogin;
 
@@ -58,9 +54,6 @@ public class User {
         }
         if (userDto.getGender() != null) {
             this.gender = userDto.getGender(); // 문자열로 설정
-        }
-        if (userDto.getAddress() != null && !userDto.getAddress().isEmpty()) {
-            this.address = userDto.getAddress();
         }
     }
 
@@ -80,7 +73,6 @@ public class User {
                 .birth(birth)
                 .name(name)
                 .gender(gender)
-                .address(address)
                 .lastLogin(lastLogin)
                 .build();
     }


### PR DESCRIPTION
# BP-30: 회원정보 주소항목 제거

## 변경 사항 요약 (Summary of Changes)
이번 풀리퀘스트는 사용자 정보 모델에서 주소 항목을 제거하는 작업을 포함하고 있습니다. 이를 통해 사용자 데이터의 간결성을 유지하고, 주소 관련 데이터 처리 및 저장을 불필요하게 하는 목적입니다.

- **BP-30 chore: 회원정보 주소항목 제거**
  - 사용자 정보 모델에서 주소 관련 필드를 제거했습니다.
  - 데이터베이스 스키마에서 주소 관련 컬럼을 삭제했습니다.
  - 관련된 API 엔드포인트와 데이터 처리 로직에서 주소 항목을 제거했습니다.

## 배경 및 목적 (Background and Motivation)
주소 정보는 현재 사용자 데이터에서 필요하지 않거나, 다른 시스템에서 관리되고 있는 경우가 있습니다. 이 변경은 데이터베이스와 API 모델을 간결하게 하고, 유지보수성을 높이기 위해 수행되었습니다.

- **사용자 정보 간소화**: 필요하지 않은 데이터를 제거하여 데이터 모델을 간결하게 유지합니다.
- **성능 및 유지보수**: 불필요한 데이터 처리 및 저장을 줄여 성능과 유지보수성을 향상시킵니다.

## 관련 이슈 (Linked Issues)
- 이 풀리퀘스트는 다음의 이슈를 해결합니다:
  - Closes #30

## 테스트 방법 (Testing Instructions)
다음 단계를 통해 이번 변경 사항을 테스트할 수 있습니다:

1. **데이터베이스 확인**
   - 데이터베이스에서 주소 관련 컬럼이 정상적으로 제거되었는지 확인합니다.
   - 기존 데이터베이스 마이그레이션이 올바르게 적용되었는지 검토합니다.

2. **API 테스트**
   - 사용자 정보를 조회하거나 업데이트하는 API 호출 시, 주소 항목이 응답에 포함되지 않는지 확인합니다.
   - 주소 항목이 제거된 상태에서도 기존의 API 기능이 정상적으로 작동하는지 테스트합니다.

3. **유닛 테스트 및 통합 테스트**
   - 사용자 정보 모델과 관련된 유닛 테스트 및 통합 테스트를 실행하여, 변경 사항이 기존 기능에 영향을 미치지 않았는지 확인합니다.

## 기타 참고 사항 (Additional Notes)
- 주소 항목 제거로 인해 사용자 관련 데이터를 처리하는 코드와 문서에서 변경된 부분이 있는지 점검할 필요가 있습니다.
- 향후 사용자 데이터 모델을 변경할 경우, 데이터의 필요성과 사용 현황을 재검토하는 것이 좋습니다.
