### PR TITLE
BP-51 HotFix:시큐리티 코드 버그 수정

### DIFF
--- a/src/main/java/com/example/basicback/disasterfetcher/DisasterApiResponse.java
+++ b/src/main/java/com/example/basicback/disasterfetcher/DisasterApiResponse.java
@@ -1,0 +1,56 @@
+package com.example.basicback.disasterfetcher;
+
+
+import java.util.List;
+
+public class DisasterApiResponse {
+    private List<Row> row;
+
+    public List<Row> getRow() {
+        return row;
+    }
+
+    public void setRow(List<Row> row) {
+        this.row = row;
+    }
+
+    public static class Row {
+        private String locationName;
+        private String msg;
+        private String md101Sn;
+        private String createDate;
+
+        // Getters and Setters
+        public String getLocationName() {
+            return locationName;
+        }
+
+        public void setLocationName(String locationName) {
+            this.locationName = locationName;
+        }
+
+        public String getMsg() {
+            return msg;
+        }
+
+        public void setMsg(String msg) {
+            this.msg = msg;
+        }
+
+        public String getMd101Sn() {
+            return md101Sn;
+        }
+
+        public void setMd101Sn(String md101Sn) {
+            this.md101Sn = md101Sn;
+        }
+
+        public String getCreateDate() {
+            return createDate;
+        }
+
+        public void setCreateDate(String createDate) {
+            this.createDate = createDate;
+        }
+    }
+}

--- a/src/main/java/com/example/basicback/disasterfetcher/DisasterFetcher.java
+++ b/src/main/java/com/example/basicback/disasterfetcher/DisasterFetcher.java
@@ -1,0 +1,89 @@
+package com.example.basicback.disasterfetcher;
+
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.logging.Logger;
+
+public class DisasterFetcher {
+
+    private static final Logger log = Logger.getLogger(DisasterFetcher.class.getName());
+    private String apiKey = "";  // Replace with your API key
+    private String apiUrl = "";  // Replace with your API URL
+
+    public List<DisasterMessage> fetchDisasterMessages() {
+        List<DisasterMessage> messages = new ArrayList<>();
+        log.info("Starting fetchDisasterMessages scheduled task");
+        try {
+            String encodedServiceKey = URLEncoder.encode(apiKey, StandardCharsets.UTF_8.toString());
+            log.info("Encoded service key: " + encodedServiceKey);
+
+            String url = apiUrl + "?serviceKey=" + encodedServiceKey + "&type=xml&pageNo=1&numOfRows=10&flag=Y";
+            log.info("API Request URL: " + url);
+
+            URL apiEndpoint = new URL(url);
+            HttpURLConnection connection = (HttpURLConnection) apiEndpoint.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Accept", "application/xml");
+
+            log.info("Sending request to API");
+            int responseCode = connection.getResponseCode();
+            log.info("API Response Status: " + responseCode);
+
+            if (responseCode == 200) {
+                Scanner scanner = new Scanner(apiEndpoint.openStream());
+                String response = scanner.useDelimiter("\\A").next();
+                scanner.close();
+
+                log.info("Response: " + response);
+
+                // XML 파싱을 수행합니다.
+                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                DocumentBuilder builder = factory.newDocumentBuilder();
+                Document doc = builder.parse(new java.io.ByteArrayInputStream(response.getBytes(StandardCharsets.UTF_8)));
+
+                NodeList rowNodes = doc.getElementsByTagName("row");
+
+                for (int i = 0; i < rowNodes.getLength(); i++) {
+                    Element rowElement = (Element) rowNodes.item(i);
+
+                    String createDateStr = rowElement.getElementsByTagName("create_date").item(0).getTextContent();
+                    String locationName = rowElement.getElementsByTagName("location_name").item(0).getTextContent();
+                    String md101Sn = rowElement.getElementsByTagName("md101_sn").item(0).getTextContent();
+                    String msg = rowElement.getElementsByTagName("msg").item(0).getTextContent();
+
+                    DisasterMessage message = new DisasterMessage();
+                    message.setLocationName(locationName);
+                    message.setMessage(msg);
+                    message.setMd101Sn(md101Sn);
+                    message.setCreateDate(LocalDateTime.parse(createDateStr, DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")));
+
+                    log.info("Parsed disaster message: locationName=" + message.getLocationName()
+                            + ", md101Sn=" + message.getMd101Sn() + ", createDate=" + message.getCreateDate());
+
+                    messages.add(message);
+                }
+            } else {
+                log.warning("No disaster messages found in the API response");
+            }
+        } catch (Exception e) {
+            log.severe("Error fetching disaster messages: " + e.getMessage());
+            e.printStackTrace();
+        }
+        log.info("Completed fetchDisasterMessages scheduled task");
+        return messages;
+    }
+}

--- a/src/main/java/com/example/basicback/disasterfetcher/DisasterFetcherTest.java
+++ b/src/main/java/com/example/basicback/disasterfetcher/DisasterFetcherTest.java
@@ -1,0 +1,21 @@
+package com.example.basicback.disasterfetcher;
+
+
+import java.util.List;
+
+public class DisasterFetcherTest {
+
+    public static void main(String[] args) {
+        DisasterFetcher fetcher = new DisasterFetcher();
+        List<DisasterMessage> messages = fetcher.fetchDisasterMessages();
+
+        // 전체 리스트를 출력합니다.
+        for (DisasterMessage message : messages) {
+            System.out.println("Location: " + message.getLocationName());
+            System.out.println("Message: " + message.getMessage());
+            System.out.println("Created Date: " + message.getCreateDate());
+            System.out.println("MD101 SN: " + message.getMd101Sn());
+            System.out.println("-------------------------");
+        }
+    }
+}

--- a/src/main/java/com/example/basicback/disasterfetcher/DisasterMessage.java
+++ b/src/main/java/com/example/basicback/disasterfetcher/DisasterMessage.java
@@ -1,0 +1,44 @@
+package com.example.basicback.disasterfetcher;
+
+
+import java.time.LocalDateTime;
+
+public class DisasterMessage {
+    private String locationName;
+    private String message;
+    private String md101Sn;
+    private LocalDateTime createDate;
+
+    // Getters and Setters
+    public String getLocationName() {
+        return locationName;
+    }
+
+    public void setLocationName(String locationName) {
+        this.locationName = locationName;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMd101Sn() {
+        return md101Sn;
+    }
+
+    public void setMd101Sn(String md101Sn) {
+        this.md101Sn = md101Sn;
+    }
+
+    public LocalDateTime getCreateDate() {
+        return createDate;
+    }
+
+    public void setCreateDate(LocalDateTime createDate) {
+        this.createDate = createDate;
+    }
+}


### PR DESCRIPTION
# 주제

- 자연 재해 관련 정보 처리 기능 추가

# 작업 완료 내용 (자세히 작성)

- `DisasterApiResponse`, `DisasterFetcher`, `DisasterFetcherTest`, `DisasterMessage` 클래스 추가.
- 자연 재해 데이터를 받아와 XML 형식에서 필요한 정보를 파싱하는 `DisasterFetcher` 클래스 구현.
- 파싱된 데이터를 저장하는 `DisasterMessage` 클래스 구현.
- API 응답을 테스트하는 `DisasterFetcherTest` 클래스 구현.
- 모든 클래스에 자바독 주석과 함께 적절한 로깅 메커니즘을 포함.

# 관련 이슈 번호

- ✅ Closes: BP-51

# 미작업 내용

- 데이터베이스 저장 기능 구현

# 주의사항

- [ ] API 키와 URL은 보안상의 이유로 코드에서 제외하고 환경 변수 또는 설정 파일에서 관리해야 함.
- [ ] 실제 서비스 배포 전에 각 메서드의 예외 처리를 충분히 검토하고, 필요에 따라 예외 로깅을 강화해야 함.
